### PR TITLE
Fix delivery.message.ttl handling

### DIFF
--- a/mqlight.js
+++ b/mqlight.js
@@ -928,7 +928,7 @@ var processMessage = function(client, receiver, protonMsg) {
         link.substring(link.indexOf(':') + 1, link.length);
   }
   if (protonMsg.header.ttl > 0) {
-    delivery.message.ttl = protonMsg.ttl;
+    delivery.message.ttl = protonMsg.header.ttl;
   }
 
   if (protonMsg.applicationProperties) {


### PR DESCRIPTION
The referenced attribute was incorrectly named and so wouldn't get added to the delivery.message object on receipt.