### PR TITLE
Handle valid JSON that doesn't contain service definitions

### DIFF
--- a/mqlight.js
+++ b/mqlight.js
@@ -1459,23 +1459,22 @@ var Client = function(service, id, securityOptions) {
               client._serviceFunction(serviceFunctionCallback);
             }, 5000);
           }
+        } else if (typeof service === 'undefined') {
+          var message = 'service lookup response does not ' +
+                        'contain any service definitions';
+          var error = new NetworkError(message);
+          logger.log('error', client.id, error);
+          client.emit('error', error);
         } else {
-          if (typeof service === 'undefined') {
-            var message = 'service lookup response does not contain any service definitions';
-            var error = new NetworkError(message);
-            logger.log('error', client.id, error);
-            client.emit('error', error);
-          } else {
-            try {
-              client._setState(STATE_STARTING);
-              serviceList =
-                  client._generateServiceList(service);
-              client._connectToService(serviceList);
-            } catch (err) {
-              logger.caught('_serviceFunction', client.id, err);
-              client._setState(STATE_STOPPED);
-              client._invokeStartedCallbacks(err);
-            }
+          try {
+            client._setState(STATE_STARTING);
+            serviceList =
+                client._generateServiceList(service);
+            client._connectToService(serviceList);
+          } catch (err) {
+            logger.caught('_serviceFunction', client.id, err);
+            client._setState(STATE_STOPPED);
+            client._invokeStartedCallbacks(err);
           }
         }
       };

--- a/mqlight.js
+++ b/mqlight.js
@@ -1460,15 +1460,22 @@ var Client = function(service, id, securityOptions) {
             }, 5000);
           }
         } else {
-          try {
-            client._setState(STATE_STARTING);
-            serviceList =
-                client._generateServiceList(service);
-            client._connectToService(serviceList);
-          } catch (err) {
-            logger.caught('_serviceFunction', client.id, err);
-            client._setState(STATE_STOPPED);
-            client._invokeStartedCallbacks(err);
+          if (typeof service === 'undefined') {
+            var message = 'service lookup response does not contain any service definitions';
+            var error = new NetworkError(message);
+            logger.log('error', client.id, error);
+            client.emit('error', error);
+          } else {
+            try {
+              client._setState(STATE_STARTING);
+              serviceList =
+                  client._generateServiceList(service);
+              client._connectToService(serviceList);
+            } catch (err) {
+              logger.caught('_serviceFunction', client.id, err);
+              client._setState(STATE_STOPPED);
+              client._invokeStartedCallbacks(err);
+            }
           }
         }
       };


### PR DESCRIPTION
If a valid JSON payload is received during service lookup but it doesn't
contain any service definitions we ffdc. It would be better to emit a
NetworkError that the client can handle.

@dnwe I'm not sure if it's necessary to emit an error to the client and log it explicitly?

fixes #14 