### PR TITLE
Don't use Infinity for timeout duration

### DIFF
--- a/mqlight.js
+++ b/mqlight.js
@@ -48,7 +48,7 @@ var https = require('https');
 
 var AMQP = require('mqlight-forked-amqp10');
 var linkCache = require('amqp10-link-cache');
-AMQP.use(linkCache({ttl: Infinity}));
+AMQP.use(linkCache({ttl: 2147483647}));
 
 var invalidClientIdRegex = /[^A-Za-z0-9%/._]+/;
 var pemCertRegex = new RegExp('-----BEGIN CERTIFICATE-----(.|[\r\n])*?' +


### PR DESCRIPTION
From Nodejs 9 onward, setTimeout() will emit a warning if the timeout is larger than the maximum 32-bit unsigned integer. https://nodejs.org/en/blog/release/v9.0.0/

We could ensure user provided timeouts are also within bounds but trying to keep the change minimal.

Fixes #16